### PR TITLE
add init from key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# 1.2.0
+
+- Add Enum::initFromKey($key)
+
+# 1.1.0
+
+- Add flip() and fromValue()
+
+# 1.0.0
+
+- initial release
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# 1.2.0
+# [Unreleased]
 
-- Add Enum::initFromKey($key)
+- Add Enum::instanceFromKey($key)
 
 # 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Animal::DOG()->value();             // (null)  - No value was assigned in map()
 
 Animal::PIGEON()->key();            // "skyrat"
 Animal::PIGEON()->value();          // (array)['you', 'filthy', 'animal']
+
+// Init from key in variable
+$kitty = 'kitty';
+$cat = Animal::initFromKey($kitty);
 ```
 
 ## Dependencies
@@ -206,6 +210,10 @@ Returns the value (or null if not mapped) for the given key (as declared in the 
 
 Returns the constant for the given value (as declared in the `map()` method).
 > Caveats: Only works with single dimension arrays and it will only return the last key if multiple keys have the same value.
+
+### initFromKey($key)
+
+Create instance of this Enum from the key.
 
 ### exists(string $key)
 

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ Animal::DOG()->value();             // (null)  - No value was assigned in map()
 Animal::PIGEON()->key();            // "skyrat"
 Animal::PIGEON()->value();          // (array)['you', 'filthy', 'animal']
 
-// Init from key in variable
+// Get a new Enum instance from a given key
 $kitty = 'kitty';
-$cat = Animal::initFromKey($kitty);
+$cat = Animal::instanceFromKey($kitty);
 ```
 
 ## Dependencies
@@ -211,9 +211,9 @@ Returns the value (or null if not mapped) for the given key (as declared in the 
 Returns the constant for the given value (as declared in the `map()` method).
 > Caveats: Only works with single dimension arrays and it will only return the last key if multiple keys have the same value.
 
-### initFromKey($key)
+### instanceFromKey($key)
 
-Create instance of this Enum from the key.
+Create instance of this Enum from the given key.
 
 ### exists(string $key)
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -210,7 +210,7 @@ abstract class Enum
      * @return static
      * @throws InvalidKeyException
      */
-    public static function initFromKey($key): self
+    public static function instanceFromKey($key): self
     {
         foreach (self::constantMap() as $identifier => $validKey) {
             if ($key === $validKey) {

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -203,6 +203,23 @@ abstract class Enum
     }
 
     /**
+     * @param string|int $key
+     *
+     * @return Enum
+     * @throws InvalidKeyException
+     */
+    public static function initFromKey($key): self
+    {
+        foreach (self::constantMap() as $identifier => $validKey) {
+            if ($key === $validKey) {
+                return static::{$identifier}();
+            }
+        }
+
+        throw new InvalidKeyException(sprintf('Invalid key: %s in %s', $key, static::class));
+    }
+
+    /**
      * Determine if a key exists within the constant map
      *
      * @param mixed|string $key

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -203,6 +203,8 @@ abstract class Enum
     }
 
     /**
+     * Create instance of this Enum from the key.
+     *
      * @param string|int $key
      *
      * @return Enum

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -207,7 +207,7 @@ abstract class Enum
      *
      * @param string|int $key
      *
-     * @return Enum
+     * @return static
      * @throws InvalidKeyException
      */
     public static function initFromKey($key): self

--- a/tests/Unit/EnumTest.php
+++ b/tests/Unit/EnumTest.php
@@ -178,4 +178,16 @@ class EnumTest extends TestCase
         $this->expectException(InvalidValueException::class);
         $this->assertEquals(Bevs::BREW, Bevs::fromValue('Water'));
     }
+
+    public function test_get_instance_via_key()
+    {
+        $animal = Animal::instanceFromKey('kitty');
+        $this->assertTrue($animal->is(Animal::CAT()));
+    }
+
+    public function test_get_instance_via_invalid_key_throws_exception()
+    {
+        $this->expectException(InvalidKeyException::class);
+        Animal::instanceFromKey('_invalid_key_');
+    }
 }


### PR DESCRIPTION
Added `initFromKey($key)` to get an enum instance from the key.

Mostly useful to convert the db value stored into the Enum on a model.

```
class Animal extends Enum
{
    const CAT = 'kitty';
    const DOG = 'dog';
    const HORSE = 'horse';
    const PIGEON = 'skyrat';
}

// Init from key in variable (probably loaded from db, or submitted by user)
$kitty = 'kitty'; 
$cat = Animal::initFromKey($kitty);
```