### PR TITLE
Feature/refactor api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ which maps keys to `null` values.
 - **Breaking** Change `Enum::fromValue($val)` has been renamed to `Enum::keyForValue()`
 - **Breaking** Change: removed `Enum::flip()`
 - **Breaking** Change `Enum::constantMap()` to `Enum::namesAndKeys()`
+- Updated README to reflect API changes
 
 # 1.1.0
 - **Breaki

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - **Breaking** Change `Enum::getKeyForIdentfier()` to `Enum::keyForName()`
 - **Breaking** Change `Enum::valueFor()` to `Enum::valueForKey()`
 - Add `Enum::nameForKey()` to get the constant name for a given key
+- **Breaking** Change `Enum::exists()` to `Enum::isValidKey()`
+- **Breaking** Change `Enum::checkExists()` to `Enum::requireValidKey()`
 
 # 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# [Unreleased]
+# 2.0.0
+
+This release is a significant overhaul of the existing API, and therefore introduces breaking changes.
+See the list of updates below, and consult the [README](./README.md) for examples and details of the new API.
 
 - Add Enum::instanceFromKey($key)
 - **Breaking** Change `$instance->identifier` to `$instance->name()`
@@ -25,7 +28,6 @@ which maps keys to `null` values.
 - Add `Enum::valueForName($name)` for completeness
 
 # 1.1.0
-- **Breaki
 
 - Add flip() and fromValue()
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix `$instance->key()` to handle non-string keys
 - Fix `$instance->is()` to handle non-string keys
 - Fix late-static binding in some methods which referred to `self::`
+- Add `Enum::instanceFromName($name)` to get an instance via name (alternative to Enum::NAME())
 
 # 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # [Unreleased]
 
 - Add Enum::instanceFromKey($key)
+- **Breaking** Change `$instance->identifier` to `$instance->name()`
+- **Breaking** Change `Enum::identifiers()` to `Enum::names()`
+- **Breaking** Change `Enum::getKeyForIdentfier()` to `Enum::keyForName()`
 
 # 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ which maps keys to `null` values.
 - **Breaking** Change: removed `Enum::flip()`
 - **Breaking** Change `Enum::constantMap()` to `Enum::namesAndKeys()`
 - Updated README to reflect API changes
+- Add `Enum::valueForName($name)` for completeness
 
 # 1.1.0
 - **Breaki

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **Breaking** Change `$instance->identifier` to `$instance->name()`
 - **Breaking** Change `Enum::identifiers()` to `Enum::names()`
 - **Breaking** Change `Enum::getKeyForIdentfier()` to `Enum::keyForName()`
+- **Breaking** Change `Enum::valueFor()` to `Enum::valueForKey()`
 
 # 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix `$instance->is()` to handle non-string keys
 - Fix late-static binding in some methods which referred to `self::`
 - Add `Enum::instanceFromName($name)` to get an instance via name (alternative to Enum::NAME())
+- Change implementation of `Enum::instanceFromKey($key)` to use array_search
 
 # 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Breaking** Change `Enum::identifiers()` to `Enum::names()`
 - **Breaking** Change `Enum::getKeyForIdentfier()` to `Enum::keyForName()`
 - **Breaking** Change `Enum::valueFor()` to `Enum::valueForKey()`
+- Add `Enum::nameForKey()` to get the constant name for a given key
 
 # 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ in your sub-class.  This method should be used to map keys to values (if necessa
 which maps keys to `null` values.
 - **Breaking** Change `Enum::fromValue($val)` has been renamed to `Enum::keyForValue()`
 - **Breaking** Change: removed `Enum::flip()`
+- **Breaking** Change `Enum::constantMap()` to `Enum::namesAndKeys()`
 
 # 1.1.0
 - **Breaki

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **Breaking** Change `Enum::checkExists()` to `Enum::requireValidKey()`
 - Fix `$instance->key()` to handle non-string keys
 - Fix `$instance->is()` to handle non-string keys
+- Fix late-static binding in some methods which referred to `self::`
 
 # 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add `Enum::nameForKey()` to get the constant name for a given key
 - **Breaking** Change `Enum::exists()` to `Enum::isValidKey()`
 - **Breaking** Change `Enum::checkExists()` to `Enum::requireValidKey()`
+- Fix `$instance->key()` to handle non-string keys
 
 # 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,16 @@
 - Fix late-static binding in some methods which referred to `self::`
 - Add `Enum::instanceFromName($name)` to get an instance via name (alternative to Enum::NAME())
 - Change implementation of `Enum::instanceFromKey($key)` to use array_search
+- **Breaking** Change: the default provided static `map()` method will return an array of constant keys mapped to `null`. 
+Previously it returned an empty array `[]` when not overridden. In practice, this may not effect userland code.
+- **Breaking** Change: you can no longer provide a non-keyed array in an `map()` method implemented
+in your sub-class.  This method should be used to map keys to values (if necessary).  A default map() method is provided
+which maps keys to `null` values.
+- **Breaking** Change `Enum::fromValue($val)` has been renamed to `Enum::keyForValue()`
+- **Breaking** Change: removed `Enum::flip()`
 
 # 1.1.0
+- **Breaki
 
 - Add flip() and fromValue()
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **Breaking** Change `Enum::exists()` to `Enum::isValidKey()`
 - **Breaking** Change `Enum::checkExists()` to `Enum::requireValidKey()`
 - Fix `$instance->key()` to handle non-string keys
+- Fix `$instance->is()` to handle non-string keys
 
 # 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ echo Animal::CAT;                   // "kitty"
 
 // Get an Animal instance for 'CAT'
 $cat = Animal::CAT();               // (object)Animal
-$cat->identifier();                 // "CAT"
+$cat->name();                       // "CAT"
 $cat->key();                        // "kitty"
 $cat->value();                      // "Kitty-cat"
 $cat->is(Animal::CAT);              // (boolean)true
@@ -109,7 +109,7 @@ function sayHelloTo(Animal $animal) {
         $name = implode(' ', $name);
     }
 
-    echo "Greeting for {$animal->identifier()}: Hello $name\n";
+    echo "Greeting for {$animal->name()}: Hello $name\n";
 
 }
 
@@ -124,12 +124,12 @@ sayHelloTo(Animal::PIGEON());   // "Greeting for PIGEON: Hello you filthy animal
 
 Each instance of `Enum` provides the following methods:
 
-### identifier()
+### name()
 
-Returns the constant identifier.
+Returns the constant name.
 
 ```php
-$enum->identifier();
+$enum->name();
 ```
 
 ### key()
@@ -160,7 +160,7 @@ $enum->is(Animal::CAT());     // Compare to instance
 
 ### __toString()
 
-The `__toString()` method is defined to return the instance identifier (constant name).
+The `__toString()` method is defined to return the constant name.
 
 ```php
 (string)Animal::CAT();      // "CAT"
@@ -186,21 +186,21 @@ Returns an array of constant keys.
 Returns an array of values defined in `map()`. If `map()` is not implemented then an array of null values will
 be returned.
 
-### identifiers()
+### names()
 
-Returns an array of all the constant identifiers declared with `const MY_CONST = 'key'`
+Returns an array of all the constant names declared with the class.
 
 ### constantMap()
 
-Returns an array of CONST => key, for all of the constant identifiers declared with `const MY_CONST = 'key'`.
+Returns an array of CONST => key, for all of the constant names declared within the class.
 
-### getKeyForIdentifier(string $identifier)
+### getKeyForName(string $name)
 
-Returns the key for the given constant identifier.
+Returns the key for the given constant name.
 
-### identifierExists(string $identifier)
+### nameExists(string $name)
 
-Returns true if the given identifier is declared as a `const` within the class.
+Returns true if the given name is declared as a `const` within the class.
 
 ### valueFor(string $key)
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -298,9 +298,9 @@ abstract class Enum
     /**
      * Returns the value assigned to the constant declaration.
      *
-     * @return mixed|string
+     * @return mixed|string|int
      */
-    public function key(): string
+    public function key()
     {
         return $this->key;
     }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -123,7 +123,7 @@ abstract class Enum
     }
 
     /**
-     * Return a map of constant names and their assigned key value.
+     * Return a map of constant names and their associated key.
      *
      * @return array
      */
@@ -173,11 +173,11 @@ abstract class Enum
     }
 
     /**
-     * Get the value for a given key
+     * Get the value for a given key.
      *
-     * @param mixed|string $key
+     * @param mixed|int|string $key
      *
-     * @return mixed
+     * @return mixed|null
      * @throws InvalidKeyException
      */
     public static function valueForKey($key)
@@ -185,6 +185,24 @@ abstract class Enum
         static::checkExists($key);
 
         return static::cachedMap()[$key];
+    }
+
+    /**
+     * Get the constant name for a given key.
+     *
+     * @param mixed|int|string $key
+     *
+     * @return string
+     * @throws InvalidKeyException
+     */
+    public static function nameForKey($key): string
+    {
+        $name = array_search($key, self::constantMap(), true);
+        if ($name === false) {
+            throw new InvalidKeyException("Invalid key: $key in " . static::class);
+        }
+
+        return $name;
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -158,7 +158,7 @@ abstract class Enum
     }
 
     /**
-     * Get the key for the given constant name
+     * Get the key for the given constant name.
      *
      * @param string $name
      *
@@ -166,10 +166,7 @@ abstract class Enum
      */
     public static function keyForName(string $name)
     {
-        $key = null;
-        $map = static::constantMap();
-
-        return $map[$name] ?? null;
+        return static::constantMap()[$name] ?? null;
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -182,7 +182,7 @@ abstract class Enum
      */
     public static function valueForKey($key)
     {
-        static::checkExists($key);
+        static::requireValidKey($key);
 
         return static::cachedMap()[$key];
     }
@@ -247,7 +247,7 @@ abstract class Enum
      *
      * @return boolean
      */
-    public static function exists($key): bool
+    public static function isValidKey($key): bool
     {
         return array_key_exists($key, static::cachedMap());
     }
@@ -255,13 +255,13 @@ abstract class Enum
     /**
      * Check if the key exists or throw an exception
      *
-     * @param mixed|string $key
+     * @param mixed|string|int $key
      *
      * @throws InvalidKeyException
      */
-    public static function checkExists($key)
+    public static function requireValidKey($key)
     {
-        if (!static::exists($key)) {
+        if (!static::isValidKey($key)) {
             throw new InvalidKeyException("Invalid key: $key in " . static::class);
         }
     }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -194,7 +194,7 @@ abstract class Enum
      */
     public static function nameForKey($key): string
     {
-        $name = array_search($key, self::constantMap(), true);
+        $name = array_search($key, static::constantMap(), true);
         if ($name === false) {
             throw new InvalidKeyException("Invalid key: $key in " . static::class);
         }
@@ -228,7 +228,7 @@ abstract class Enum
      */
     public static function instanceFromKey($key): self
     {
-        foreach (self::constantMap() as $name => $validKey) {
+        foreach (static::constantMap() as $name => $validKey) {
             if ($key === $validKey) {
                 return static::{$name}();
             }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -247,13 +247,11 @@ abstract class Enum
      */
     public static function instanceFromKey($key): self
     {
-        foreach (static::constantMap() as $name => $validKey) {
-            if ($key === $validKey) {
-                return static::{$name}();
-            }
+        $name = array_search($key, static::constantMap(), true);
+        if ($name === false) {
+            throw new InvalidKeyException(sprintf('Invalid key: %s in %s', $key, static::class));
         }
-
-        throw new InvalidKeyException(sprintf('Invalid key: %s in %s', $key, static::class));
+        return static::{$name}();
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -145,10 +145,16 @@ abstract class Enum
      * @param string $name
      *
      * @return null|mixed|string
+     * @throws InvalidEnumException
      */
     public static function keyForName(string $name)
     {
-        return static::namesAndKeys()[$name] ?? null;
+        $key = static::namesAndKeys()[$name] ?? null;
+        if (!$key) {
+            throw new InvalidEnumException("Invalid constant name: $name in " . static::class);
+        }
+
+        return $key;
     }
 
     /**
@@ -164,6 +170,21 @@ abstract class Enum
         static::requireValidKey($key);
 
         return static::cachedMap()[$key];
+    }
+
+    /**
+     * Get the value for a given constant name.
+     *
+     * @param string $name
+     *
+     * @return mixed|null
+     * @throws InvalidEnumException
+     */
+    public static function valueForName($name)
+    {
+        $key = static::keyForName($name);
+
+        return static::cachedMap()[$key] ?? null;
     }
 
     /**
@@ -275,7 +296,7 @@ abstract class Enum
      */
     public static function isValidName(string $name): bool
     {
-        return static::keyForName($name) !== null;
+        return isset(static::namesAndKeys()[$name]);
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -65,16 +65,7 @@ abstract class Enum
         // Ensure the map is indexed by key
         $class = static::class;
         if (!isset(static::$keysToValuesMap[$class])) {
-            $cache = null;
-            $map = static::map();
-            if (!empty($map)) {
-                $isAssoc = array_keys($map) !== range(0, \count($map) - 1);
-                $cache = $isAssoc ? $map : array_fill_keys(array_values($map), null);
-            } else {
-                // No mapping is defined, use the const keys
-                $cache = array_fill_keys(array_values(static::constantMap()), null);
-            }
-            static::$keysToValuesMap[$class] = $cache;
+            static::$keysToValuesMap[$class] = static::map();
         }
 
         return static::$keysToValuesMap[$class];
@@ -88,17 +79,7 @@ abstract class Enum
      */
     public static function map(): array
     {
-        return [];
-    }
-
-    /**
-     * Return flipped map where keys become values and vice versa
-     *
-     * @return array
-     */
-    public static function flip(): array
-    {
-        return array_flip(static::map()) ?? [];
+        return array_fill_keys(array_values(static::constantMap()), null);
     }
 
     /**
@@ -203,19 +184,21 @@ abstract class Enum
     }
 
     /**
-     * Returns the constant for a given value
+     * Returns the key for a given value (an inverted search).
+     * Since keys can be assigned the same value, only the first match will be
+     * returned.
      *
-     * @param str|int $value
-     * @return Mixed
+     * @param mixed $value
+     * @return mixed
      */
-    public static function fromValue($value)
+    public static function keyForValue($value)
     {
-        $flipped = static::flip();
-        if ( ! array_key_exists( $value, $flipped )) {
+        $key = array_search($value, static::cachedMap(), true);
+        if ($key === false) {
             throw new InvalidValueException("Value '{$value}' not found in map for " . static::class);
         }
 
-        return $flipped[$value];
+        return $key;
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -2,6 +2,7 @@
 
 namespace Rexlabs\Enum;
 
+use Rexlabs\Enum\Exceptions\DuplicateKeyException;
 use Rexlabs\Enum\Exceptions\InvalidEnumException;
 use Rexlabs\Enum\Exceptions\InvalidKeyException;
 use Rexlabs\Enum\Exceptions\InvalidValueException;
@@ -175,12 +176,15 @@ abstract class Enum
      */
     public static function nameForKey($key): string
     {
-        $name = array_search($key, static::constantMap(), true);
-        if ($name === false) {
+        $matches = array_keys(static::constantMap(), $key, true);
+        $numMatches = \count($matches);
+        if (!$numMatches) {
             throw new InvalidKeyException("Invalid key: $key in " . static::class);
         }
-
-        return $name;
+        if ($numMatches > 1) {
+            throw new DuplicateKeyException("Unable to resolve name for $key, duplicate matches in " . static::class);
+        }
+        return $matches[0];
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -296,7 +296,7 @@ abstract class Enum
      */
     public static function isValidName(string $name): bool
     {
-        return isset(static::namesAndKeys()[$name]);
+        return array_key_exists($name, static::namesAndKeys());
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -318,7 +318,7 @@ abstract class Enum
     /**
      * Returns true if this instance is equal to the given key or Enum instance.
      *
-     * @param Enum|string $compare
+     * @param static|mixed $compare
      *
      * @return bool
      * @throws InvalidEnumException
@@ -329,10 +329,10 @@ abstract class Enum
             return $compare->name() === $this->name();
         }
 
-        if (\is_string($compare)) {
+        if (\is_scalar($compare)) {
             return $compare === $this->key();
         }
 
-        throw new InvalidEnumException('Enum or string expected but ' . \gettype($compare) . ' given.');
+        throw new InvalidEnumException('Enum instance or key (scalar) expected but ' . \gettype($compare) . ' given.');
     }
 }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -154,7 +154,7 @@ abstract class Enum
             throw new InvalidEnumException("Invalid constant name '{$name}' in " . static::class);
         }
 
-        return new static($name, $key, static::valueFor($key));
+        return new static($name, $key, static::valueForKey($key));
     }
 
     /**
@@ -180,7 +180,7 @@ abstract class Enum
      * @return mixed
      * @throws InvalidKeyException
      */
-    public static function valueFor($key)
+    public static function valueForKey($key)
     {
         static::checkExists($key);
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -219,6 +219,25 @@ abstract class Enum
     }
 
     /**
+     * Create instance of this Enum from the constant name.
+     * This method is case-sensitive, meaning if you declare your constant
+     * as const MY_CONST = '...', then you will need to provide 'MY_CONST' as
+     * the argument.
+     *
+     * @param string $name
+     *
+     * @return static
+     * @throws InvalidEnumException
+     */
+    public static function instanceFromName($name): self
+    {
+        if (!array_key_exists($name, static::constantMap())) {
+            throw new InvalidEnumException(sprintf('Invalid constant name: %s in %s', $name, static::class));
+        }
+        return static::{$name}();
+    }
+
+    /**
      * Create instance of this Enum from the key.
      *
      * @param string|int $key

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -14,11 +14,11 @@ use Rexlabs\Enum\Exceptions\InvalidValueException;
  */
 abstract class Enum
 {
-    /** @var array Cache of constant name => value per class */
-    public static $constants = [];
+    /** @var array Cache of constant name => key per class */
+    public static $namesToKeysMap = [];
 
-    /** @var array Cache of what map() returns per class */
-    public static $cachedMap = [];
+    /** @var array Cache of key => value per class (santized version of what map() returns) */
+    public static $keysToValuesMap = [];
 
     /** @var string */
     protected $name;
@@ -64,7 +64,7 @@ abstract class Enum
     {
         // Ensure the map is indexed by key
         $class = static::class;
-        if (!isset(static::$cachedMap[$class])) {
+        if (!isset(static::$keysToValuesMap[$class])) {
             $cache = null;
             $map = static::map();
             if (!empty($map)) {
@@ -74,10 +74,10 @@ abstract class Enum
                 // No mapping is defined, use the const keys
                 $cache = array_fill_keys(array_values(static::constantMap()), null);
             }
-            static::$cachedMap[$class] = $cache;
+            static::$keysToValuesMap[$class] = $cache;
         }
 
-        return static::$cachedMap[$class];
+        return static::$keysToValuesMap[$class];
     }
 
     /**
@@ -130,11 +130,11 @@ abstract class Enum
     public static function constantMap(): array
     {
         $class = static::class;
-        if (!array_key_exists($class, static::$constants)) {
-            static::$constants[$class] = (new \ReflectionClass($class))->getConstants();
+        if (!array_key_exists($class, static::$namesToKeysMap)) {
+            static::$namesToKeysMap[$class] = (new \ReflectionClass($class))->getConstants();
         }
 
-        return static::$constants[$class];
+        return static::$namesToKeysMap[$class];
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -80,7 +80,7 @@ abstract class Enum
      */
     public static function map(): array
     {
-        return array_fill_keys(array_values(static::constantMap()), null);
+        return array_fill_keys(array_values(static::namesAndKeys()), null);
     }
 
     /**
@@ -101,7 +101,7 @@ abstract class Enum
      */
     public static function names(): array
     {
-        return array_keys(static::constantMap());
+        return array_keys(static::namesAndKeys());
     }
 
     /**
@@ -109,7 +109,7 @@ abstract class Enum
      *
      * @return array
      */
-    public static function constantMap(): array
+    public static function namesAndKeys(): array
     {
         $class = static::class;
         if (!array_key_exists($class, static::$namesToKeysMap)) {
@@ -148,7 +148,7 @@ abstract class Enum
      */
     public static function keyForName(string $name)
     {
-        return static::constantMap()[$name] ?? null;
+        return static::namesAndKeys()[$name] ?? null;
     }
 
     /**
@@ -176,7 +176,7 @@ abstract class Enum
      */
     public static function nameForKey($key): string
     {
-        $matches = array_keys(static::constantMap(), $key, true);
+        $matches = array_keys(static::namesAndKeys(), $key, true);
         $numMatches = \count($matches);
         if (!$numMatches) {
             throw new InvalidKeyException("Invalid key: $key in " . static::class);
@@ -218,7 +218,7 @@ abstract class Enum
      */
     public static function instanceFromName($name): self
     {
-        if (!array_key_exists($name, static::constantMap())) {
+        if (!array_key_exists($name, static::namesAndKeys())) {
             throw new InvalidEnumException(sprintf('Invalid constant name: %s in %s', $name, static::class));
         }
         return static::{$name}();
@@ -234,7 +234,7 @@ abstract class Enum
      */
     public static function instanceFromKey($key): self
     {
-        $name = array_search($key, static::constantMap(), true);
+        $name = array_search($key, static::namesAndKeys(), true);
         if ($name === false) {
             throw new InvalidKeyException(sprintf('Invalid key: %s in %s', $key, static::class));
         }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -14,14 +14,14 @@ use Rexlabs\Enum\Exceptions\InvalidValueException;
  */
 abstract class Enum
 {
-    /** @var array Cache of CONSTANT identifier => value per class */
+    /** @var array Cache of constant name => value per class */
     public static $constants = [];
 
     /** @var array Cache of what map() returns per class */
     public static $cachedMap = [];
 
     /** @var string */
-    protected $identifier;
+    protected $name;
 
     /** @var mixed */
     protected $key;
@@ -32,13 +32,13 @@ abstract class Enum
     /**
      * Enum constructor.
      *
-     * @param string $identifier
+     * @param string $name
      * @param mixed  $key
      * @param mixed  $value
      */
-    public function __construct(string $identifier, $key, $value)
+    public function __construct(string $name, $key, $value)
     {
-        $this->identifier = $identifier;
+        $this->name = $name;
         $this->key = $key;
         $this->value = $value;
     }
@@ -112,17 +112,18 @@ abstract class Enum
     }
 
     /**
-     * Return the constant identifiers
+     * Return the constant names
+     * Each constant declared in the class will be returned.
      *
      * @return array
      */
-    public static function identifiers(): array
+    public static function names(): array
     {
         return array_keys(static::constantMap());
     }
 
     /**
-     * Return a map of constant identifiers and their assigned key value.
+     * Return a map of constant names and their assigned key value.
      *
      * @return array
      */
@@ -148,27 +149,27 @@ abstract class Enum
      */
     public static function __callStatic($name, $arguments)
     {
-        $key = static::getKeyForIdentifier($name);
+        $key = static::keyForName($name);
         if ($key === null) {
-            throw new InvalidEnumException("Invalid constant identifier '{$name}' in " . static::class);
+            throw new InvalidEnumException("Invalid constant name '{$name}' in " . static::class);
         }
 
         return new static($name, $key, static::valueFor($key));
     }
 
     /**
-     * Get the key for the given constant identifier
+     * Get the key for the given constant name
      *
-     * @param string $identifier
+     * @param string $name
      *
      * @return null|mixed|string
      */
-    public static function getKeyForIdentifier(string $identifier)
+    public static function keyForName(string $name)
     {
         $key = null;
         $map = static::constantMap();
 
-        return $map[$identifier] ?? null;
+        return $map[$name] ?? null;
     }
 
     /**
@@ -212,9 +213,9 @@ abstract class Enum
      */
     public static function instanceFromKey($key): self
     {
-        foreach (self::constantMap() as $identifier => $validKey) {
+        foreach (self::constantMap() as $name => $validKey) {
             if ($key === $validKey) {
-                return static::{$identifier}();
+                return static::{$name}();
             }
         }
 
@@ -248,34 +249,35 @@ abstract class Enum
     }
 
     /**
-     * @param string $identifier
+     * Check if the given constant name is valid.
+     * @param string $name
      *
      * @return bool
      */
-    public static function identifierExists(string $identifier): bool
+    public static function isValidName(string $name): bool
     {
-        return static::getKeyForIdentifier($identifier) !== null;
+        return static::keyForName($name) !== null;
     }
 
     /**
-     * Returns the identifier (constant).
-     * Same as $enum->identifier().
+     * Overloads the string behavior, to return the constant name.
+     * Same as $instance->name().
      *
      * @return string
      */
     public function __toString()
     {
-        return $this->identifier();
+        return $this->name();
     }
 
     /**
-     * Returns the identifier (constant).
+     * Returns the constant name.
      *
      * @return string
      */
-    public function identifier(): string
+    public function name(): string
     {
-        return $this->identifier;
+        return $this->name;
     }
 
     /**
@@ -309,7 +311,7 @@ abstract class Enum
     public function is($compare): bool
     {
         if ($compare instanceof self) {
-            return $compare->identifier() === $this->identifier();
+            return $compare->name() === $this->name();
         }
 
         if (\is_string($compare)) {

--- a/src/Exceptions/DuplicateKeyException.php
+++ b/src/Exceptions/DuplicateKeyException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rexlabs\Enum\Exceptions;
+
+class DuplicateKeyException extends EnumException
+{
+
+}

--- a/tests/Stub/Beverage.php
+++ b/tests/Stub/Beverage.php
@@ -4,7 +4,7 @@ namespace Rexlabs\Enum\Tests\Stub;
 
 use Rexlabs\Enum\Enum;
 
-class Bevs extends Enum
+class Beverage extends Enum
 {
     const BREW = 0;
     const RED_WINE = 1;

--- a/tests/Stub/DuplicateKey.php
+++ b/tests/Stub/DuplicateKey.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rexlabs\Enum\Tests\Stub;
+
+use Rexlabs\Enum\Enum;
+
+class DuplicateKey extends Enum
+{
+    const FIRST = 'duplicate';
+    const SECOND = 'duplicate';
+}

--- a/tests/Stub/Fruit.php
+++ b/tests/Stub/Fruit.php
@@ -9,4 +9,17 @@ class Fruit extends Enum
     const APPLE = 'apple';
     const BANANA = 'banana';
     const CHERRY = 'cherry';
+    const EGGPLANT = 'eggplant';
+    const AUBERGINE = 'aubergine';
+
+    public static function map(): array
+    {
+        return [
+            static::APPLE => 'Apple',
+            static::BANANA => 'Banana',
+            static::CHERRY => 'Cherry',
+            static::EGGPLANT => 'Eggplant',
+            static::AUBERGINE => 'Eggplant',
+        ];
+    }
 }

--- a/tests/Stub/Number.php
+++ b/tests/Stub/Number.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rexlabs\Enum\Tests\Stub;
+
+use Rexlabs\Enum\Enum;
+
+class Number extends Enum
+{
+    const ONE = 1;
+    const EIGHT = 8;
+    const TEN = 10;
+    const TWENTY_FOUR = 24;
+}

--- a/tests/Unit/EnumTest.php
+++ b/tests/Unit/EnumTest.php
@@ -155,6 +155,9 @@ class EnumTest extends TestCase
         $this->assertTrue(Fruit::APPLE()->is(Fruit::APPLE));
         $this->assertFalse(Fruit::APPLE()->is(Fruit::BANANA));
         $this->assertFalse(Fruit::APPLE()->is('_not_defined_'));
+
+        // When key is not a string
+        $this->assertTrue(Number::TWENTY_FOUR()->is(24));
     }
 
     public function test_comparing_enum_to_an_invalid_argument_throws_exception()

--- a/tests/Unit/EnumTest.php
+++ b/tests/Unit/EnumTest.php
@@ -10,7 +10,7 @@ use Rexlabs\Enum\Exceptions\InvalidValueException;
 use Rexlabs\Enum\Tests\Stub\Animal;
 use Rexlabs\Enum\Tests\Stub\DuplicateKey;
 use Rexlabs\Enum\Tests\Stub\Fruit;
-use Rexlabs\Enum\Tests\Stub\Bevs;
+use Rexlabs\Enum\Tests\Stub\Beverage;
 use Rexlabs\Enum\Tests\Stub\Number;
 
 class EnumTest extends TestCase
@@ -203,14 +203,14 @@ class EnumTest extends TestCase
 
     public function test_get_key_by_value()
     {
-        $this->assertEquals(Bevs::BREW, Bevs::keyForValue('Corona'));
-        $this->assertEquals(Bevs::RUM, Bevs::keyForValue('Bundaberg'));
+        $this->assertEquals(Beverage::BREW, Beverage::keyForValue('Corona'));
+        $this->assertEquals(Beverage::RUM, Beverage::keyForValue('Bundaberg'));
     }
 
     public function test_get_key_by_invalid_value_throws_exception()
     {
         $this->expectException(InvalidValueException::class);
-        $this->assertEquals(Bevs::BREW, Bevs::keyForValue('Water'));
+        $this->assertEquals(Beverage::BREW, Beverage::keyForValue('Water'));
     }
 
     public function test_get_key_by_duplicate_value_returns_first()

--- a/tests/Unit/EnumTest.php
+++ b/tests/Unit/EnumTest.php
@@ -4,10 +4,12 @@ namespace Rexlabs\Enum\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Rexlabs\Enum\Enum;
+use Rexlabs\Enum\Exceptions\DuplicateKeyException;
 use Rexlabs\Enum\Exceptions\InvalidEnumException;
 use Rexlabs\Enum\Exceptions\InvalidKeyException;
 use Rexlabs\Enum\Exceptions\InvalidValueException;
 use Rexlabs\Enum\Tests\Stub\Animal;
+use Rexlabs\Enum\Tests\Stub\DuplicateKey;
 use Rexlabs\Enum\Tests\Stub\Fruit;
 use Rexlabs\Enum\Tests\Stub\Bevs;
 use Rexlabs\Enum\Tests\Stub\Number;
@@ -103,6 +105,12 @@ class EnumTest extends TestCase
     {
         $this->expectException(InvalidKeyException::class);
         Fruit::nameForKey('_does_not_exist_');
+    }
+
+    public function test_get_name_for_duplicate_key_throws_exception()
+    {
+        $this->expectException(DuplicateKeyException::class);
+        DuplicateKey::nameForKey(DuplicateKey::FIRST);
     }
 
     public function test_can_instantiate_instance()

--- a/tests/Unit/EnumTest.php
+++ b/tests/Unit/EnumTest.php
@@ -20,6 +20,8 @@ class EnumTest extends TestCase
             'APPLE',
             'BANANA',
             'CHERRY',
+            'EGGPLANT',
+            'AUBERGINE',
         ], Fruit::names());
 
         $this->assertEquals([
@@ -36,6 +38,8 @@ class EnumTest extends TestCase
             Fruit::APPLE,
             Fruit::BANANA,
             Fruit::CHERRY,
+            Fruit::EGGPLANT,
+            Fruit::AUBERGINE,
         ], Fruit::keys());
 
         $this->assertEquals([
@@ -55,12 +59,14 @@ class EnumTest extends TestCase
 
     public function test_get_values()
     {
-        // When map() is not defined, should return an array of null
+        // Number does not provide a map() method and therefore all keys are
+        // by default mapped to a value of null
         $this->assertEquals([
             null,
             null,
             null,
-        ], Fruit::values());
+            null,
+        ], Number::values());
 
         // When map() is defined, should return all of the mapped values
         $this->assertEquals([
@@ -74,7 +80,7 @@ class EnumTest extends TestCase
     public function test_can_get_value_for_key()
     {
         // Not mapped
-        $this->assertEquals(null, Fruit::valueForKey(Fruit::APPLE));
+        $this->assertEquals(null, Number::valueForKey(Number::TWENTY_FOUR));
 
         // Mapped
         $this->assertEquals('Kitty-cat', Animal::valueForKey(Animal::CAT));
@@ -128,9 +134,8 @@ class EnumTest extends TestCase
 
     public function test_can_get_value_from_instance()
     {
-        $this->assertEquals(null, Fruit::APPLE()->value());
-        $this->assertEquals(null, Fruit::BANANA()->value());
-
+        $this->assertEquals('Apple', Fruit::APPLE()->value());
+        $this->assertEquals(null, Number::TWENTY_FOUR()->value());
         $this->assertEquals('Kitty-cat', Animal::CAT()->value());
         $this->assertEquals(null, Animal::HORSE()->value());
         $this->assertEquals(['you', 'filthy', 'animal'], Animal::PIGEON()->value());
@@ -177,27 +182,22 @@ class EnumTest extends TestCase
         $this->assertEquals(Fruit::APPLE()->name(), (string)Fruit::APPLE());
     }
 
-    public function test_flipable_trait_flips_map()
+    public function test_get_key_by_value()
     {
-        $this->assertEquals([
-            'Corona' => Bevs::BREW,
-            'Red Wine' => Bevs::RED_WINE,
-            'White Wine' => Bevs::WHITE_WINE,
-            'Bundaberg' => Bevs::RUM,
-            'Jack Daniels' => Bevs::BOURBON,
-        ], Bevs::flip());
+        $this->assertEquals(Bevs::BREW, Bevs::keyForValue('Corona'));
+        $this->assertEquals(Bevs::RUM, Bevs::keyForValue('Bundaberg'));
     }
 
-    public function test_flipable_trait_gets_constant_by_value()
-    {
-        $this->assertEquals(Bevs::BREW, Bevs::fromValue('Corona'));
-        $this->assertEquals(Bevs::RUM, Bevs::fromValue('Bundaberg'));
-    }
-
-    public function test_flipable_trait_throws_exception_with_invalid_value()
+    public function test_get_key_by_invalid_value_throws_exception()
     {
         $this->expectException(InvalidValueException::class);
-        $this->assertEquals(Bevs::BREW, Bevs::fromValue('Water'));
+        $this->assertEquals(Bevs::BREW, Bevs::keyForValue('Water'));
+    }
+
+    public function test_get_key_by_duplicate_value_returns_first()
+    {
+        // Fruit::EGGPLANT and Fruit::AUBERGINE are both mapped to 'Eggplant'
+        $this->assertEquals(Fruit::EGGPLANT, Fruit::keyForValue('Eggplant'));
     }
 
     public function test_get_instance_via_name()

--- a/tests/Unit/EnumTest.php
+++ b/tests/Unit/EnumTest.php
@@ -13,20 +13,20 @@ use Rexlabs\Enum\Tests\Stub\Bevs;
 
 class EnumTest extends TestCase
 {
-    public function test_can_get_identifiers()
+    public function test_can_get_names()
     {
         $this->assertEquals([
             'APPLE',
             'BANANA',
             'CHERRY',
-        ], Fruit::identifiers());
+        ], Fruit::names());
 
         $this->assertEquals([
             'CAT',
             'DOG',
             'HORSE',
             'PIGEON',
-        ], Animal::identifiers());
+        ], Animal::names());
     }
 
     public function test_can_get_keys()
@@ -45,10 +45,10 @@ class EnumTest extends TestCase
         ], Animal::keys());
     }
 
-    public function test_can_test_identifier_exists()
+    public function test_can_test_name_exists()
     {
-        $this->assertTrue(Fruit::identifierExists('APPLE'));
-        $this->assertFalse(Fruit::identifierExists('_does_not_exist_'));
+        $this->assertTrue(Fruit::isValidName('APPLE'));
+        $this->assertFalse(Fruit::isValidName('_does_not_exist_'));
     }
 
 
@@ -96,10 +96,10 @@ class EnumTest extends TestCase
         $this->assertInstanceOf(Animal::class, $animal);
     }
 
-    public function test_can_get_identifier_from_instance()
+    public function test_can_get_name_from_instance()
     {
-        $this->assertEquals('APPLE', Fruit::APPLE()->identifier());
-        $this->assertEquals('DOG', Animal::DOG()->identifier());
+        $this->assertEquals('APPLE', Fruit::APPLE()->name());
+        $this->assertEquals('DOG', Animal::DOG()->name());
     }
 
     public function test_can_get_key_from_instance()
@@ -145,15 +145,15 @@ class EnumTest extends TestCase
         $this->assertTrue(Fruit::APPLE()->is([]));
     }
 
-    public function test_that_getting_an_instance_from_an_invalid_identifier_throws_exception()
+    public function test_that_getting_an_instance_from_an_invalid_name_throws_exception()
     {
         $this->expectException(InvalidEnumException::class);
         Fruit::NON_EXISTENT();
     }
 
-    public function test_casting_enum_to_string_returns_identifier()
+    public function test_casting_enum_to_string_returns_name()
     {
-        $this->assertEquals(Fruit::APPLE()->identifier(), (string)Fruit::APPLE());
+        $this->assertEquals(Fruit::APPLE()->name(), (string)Fruit::APPLE());
     }
 
     public function test_flipable_trait_flips_map()

--- a/tests/Unit/EnumTest.php
+++ b/tests/Unit/EnumTest.php
@@ -200,6 +200,18 @@ class EnumTest extends TestCase
         $this->assertEquals(Bevs::BREW, Bevs::fromValue('Water'));
     }
 
+    public function test_get_instance_via_name()
+    {
+        $fruit = Fruit::instanceFromName('BANANA');
+        $this->assertInstanceOf(Fruit::class, $fruit);
+
+        $animal = Animal::instanceFromName('CAT');
+        $this->assertInstanceOf(Animal::class, $animal);
+
+        $this->expectException(InvalidEnumException::class);
+        Animal::instanceFromName('cat'); // Case sensitive
+    }
+
     public function test_get_instance_via_key()
     {
         $animal = Animal::instanceFromKey('kitty');

--- a/tests/Unit/EnumTest.php
+++ b/tests/Unit/EnumTest.php
@@ -3,7 +3,6 @@
 namespace Rexlabs\Enum\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
-use Rexlabs\Enum\Enum;
 use Rexlabs\Enum\Exceptions\DuplicateKeyException;
 use Rexlabs\Enum\Exceptions\InvalidEnumException;
 use Rexlabs\Enum\Exceptions\InvalidKeyException;
@@ -94,6 +93,18 @@ class EnumTest extends TestCase
     {
         $this->expectException(InvalidKeyException::class);
         Fruit::valueForKey('_does_not_exist_');
+    }
+
+    public function test_can_get_value_for_name()
+    {
+        $this->assertEquals('Apple', Fruit::valueForName('APPLE'));
+        $this->assertEquals(null, Number::valueForName('TWENTY_FOUR'));
+    }
+
+    public function test_value_for_invalid_name_throws_exception()
+    {
+        $this->expectException(InvalidEnumException::class);
+        Fruit::valueForName('_does_not_exist_');
     }
 
     public function test_can_get_name_for_key()

--- a/tests/Unit/EnumTest.php
+++ b/tests/Unit/EnumTest.php
@@ -87,6 +87,17 @@ class EnumTest extends TestCase
         Fruit::valueForKey('_does_not_exist_');
     }
 
+    public function test_can_get_name_for_key()
+    {
+        $this->assertEquals(Fruit::APPLE()->name(), Fruit::nameForKey(Fruit::APPLE));
+    }
+
+    public function test_get_name_for_invalid_key_throws_exception()
+    {
+        $this->expectException(InvalidKeyException::class);
+        Fruit::nameForKey('_does_not_exist_');
+    }
+
     public function test_can_instantiate_instance()
     {
         $fruit = Fruit::BANANA();

--- a/tests/Unit/EnumTest.php
+++ b/tests/Unit/EnumTest.php
@@ -73,18 +73,18 @@ class EnumTest extends TestCase
     public function test_can_get_value_for_key()
     {
         // Not mapped
-        $this->assertEquals(null, Fruit::valueFor(Fruit::APPLE));
+        $this->assertEquals(null, Fruit::valueForKey(Fruit::APPLE));
 
         // Mapped
-        $this->assertEquals('Kitty-cat', Animal::valueFor(Animal::CAT));
-        $this->assertEquals(null, Animal::valueFor(Animal::DOG));
-        $this->assertEquals(['you', 'filthy', 'animal'], Animal::valueFor('skyrat'));
+        $this->assertEquals('Kitty-cat', Animal::valueForKey(Animal::CAT));
+        $this->assertEquals(null, Animal::valueForKey(Animal::DOG));
+        $this->assertEquals(['you', 'filthy', 'animal'], Animal::valueForKey('skyrat'));
     }
 
     public function test_value_for_invalid_key_throws_exception()
     {
         $this->expectException(InvalidKeyException::class);
-        Fruit::valueFor('_does_not_exist_');
+        Fruit::valueForKey('_does_not_exist_');
     }
 
     public function test_can_instantiate_instance()

--- a/tests/Unit/EnumTest.php
+++ b/tests/Unit/EnumTest.php
@@ -10,6 +10,7 @@ use Rexlabs\Enum\Exceptions\InvalidValueException;
 use Rexlabs\Enum\Tests\Stub\Animal;
 use Rexlabs\Enum\Tests\Stub\Fruit;
 use Rexlabs\Enum\Tests\Stub\Bevs;
+use Rexlabs\Enum\Tests\Stub\Number;
 
 class EnumTest extends TestCase
 {
@@ -117,6 +118,12 @@ class EnumTest extends TestCase
     {
         $this->assertEquals('apple', Fruit::APPLE()->key());
         $this->assertEquals('dog', Animal::DOG()->key());
+    }
+
+    public function test_can_get_key_from_instance_with_int_keys()
+    {
+        $this->assertEquals(10, Number::TEN()->key());
+        $this->assertEquals(24, Number::TWENTY_FOUR()->key());
     }
 
     public function test_can_get_value_from_instance()


### PR DESCRIPTION
Refactored API as discussed in issue #3 

- Add Enum::instanceFromKey($key)
- **Breaking** Change `$instance->identifier()` to `$instance->name()`
- **Breaking** Change `Enum::identifiers()` to `Enum::names()`
- **Breaking** Change `Enum::getKeyForIdentfier()` to `Enum::keyForName()`
- **Breaking** Change `Enum::valueFor()` to `Enum::valueForKey()`
- Add `Enum::nameForKey()` to get the constant name for a given key
- **Breaking** Change `Enum::exists()` to `Enum::isValidKey()`
- **Breaking** Change `Enum::checkExists()` to `Enum::requireValidKey()`
- Fix `$instance->key()` to handle non-string keys
- Fix `$instance->is()` to handle non-string keys
- Fix late-static binding in some methods which referred to `self::`
- Add `Enum::instanceFromName($name)` to get an instance via name (alternative to Enum::NAME())
- Change implementation of `Enum::instanceFromKey($key)` to use array_search
- **Breaking** Change: the default provided static `map()` method will return an array of constant keys mapped to `null`. 
Previously it returned an empty array `[]` when not overridden. In practice, this may not effect userland code.
- **Breaking** Change: you can no longer provide a non-keyed array in an `map()` method implemented
in your sub-class.  This method should be used to map keys to values (if necessary).  A default map() method is provided
which maps keys to `null` values.
- **Breaking** Change `Enum::fromValue($val)` has been renamed to `Enum::keyForValue()`
- **Breaking** Change: removed `Enum::flip()`