### PR TITLE
InvalidEnumException for Enum::is() update

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -354,7 +354,9 @@ abstract class Enum
         if (\is_scalar($compare)) {
             return $compare === $this->key();
         }
+        
+        $given = \is_object($compare) ? \get_class($compare) . ' instance' : \gettype($compare);
 
-        throw new InvalidEnumException('Enum instance or key (scalar) expected but ' . \gettype($compare) . ' given.');
+        throw new InvalidEnumException('Enum instance or key (scalar) expected but ' . $given . ' given.');
     }
 }


### PR DESCRIPTION
`InvalidEnumException` for `Enum::is()` now mentions the class name if an object was passed to the function.