### PR TITLE
InvalidEnumException for Enum::is() update

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -354,7 +354,9 @@ abstract class Enum
         if (\is_scalar($compare)) {
             return $compare === $this->key();
         }
+        
+        $given = \is_object($compare) ? \get_class($compare) . ' instance' : \gettype($compare);
 
-        throw new InvalidEnumException('Enum instance or key (scalar) expected but ' . \gettype($compare) . ' given.');
+        throw new InvalidEnumException('Enum instance or key (scalar) expected but ' . $given . ' given.');
     }
 }

--- a/tests/Unit/EnumTest.php
+++ b/tests/Unit/EnumTest.php
@@ -187,7 +187,15 @@ class EnumTest extends TestCase
     public function test_comparing_enum_to_an_invalid_argument_throws_exception()
     {
         $this->expectException(InvalidEnumException::class);
+        $this->expectExceptionMessage('Enum instance or key (scalar) expected but array given.');
         $this->assertTrue(Fruit::APPLE()->is([]));
+    }
+
+    public function test_comparing_enum_to_an_invalid_object_throws_exception()
+    {
+        $this->expectException(InvalidEnumException::class);
+        $this->expectExceptionMessage('Enum instance or key (scalar) expected but stdClass instance given.');
+        $this->assertTrue(Fruit::APPLE()->is((object) []));
     }
 
     public function test_that_getting_an_instance_from_an_invalid_name_throws_exception()


### PR DESCRIPTION
`InvalidEnumException` for `Enum::is()` now mentions the class name if an object was passed to the function.