### PR TITLE
New feature: get instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.0
+
+- Add Enum::instances method to load set of all instances
+
 # 2.0.2
 
 - Fix bug where const val=0 could not load instance

--- a/README.md
+++ b/README.md
@@ -29,7 +29,20 @@ First create a new class that extends `\Rexlabs\Enum\Enum` and do the following;
 ```php
 <?php
 
-class City extends \Rexlabs\Enum\Enum
+namespace Rexlabs\Enum\Readme;
+
+use Rexlabs\Enum\Enum;
+
+/**
+ * Class City
+ *
+ * @package Rexlabs\Enum\Readme
+ *
+ * @method static static BRISBANE()
+ * @method static static MELBOURNE()
+ * @method static static SYDNEY()
+ */
+class City extends Enum
 {
     const BRISBANE = 'Brisbane';
     const MELBOURNE = 'Melbourne';
@@ -40,9 +53,9 @@ class City extends \Rexlabs\Enum\Enum
     public static function map(): array 
     {
         return [
-            static::BRISBANE => ["state"=>"QLD", "population"=>""],
-            static::MELBOURNE => ["state"=>"VIC", "population"=>"5m"],
-            static::SYDNEY => ["state"=>"NSW", "population"=>"5m"],
+            self::BRISBANE => ["state"=>"QLD", "population"=>""],
+            self::MELBOURNE => ["state"=>"VIC", "population"=>"5m"],
+            self::SYDNEY => ["state"=>"NSW", "population"=>"5m"],
         ];
     }
     

--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ Returns an array which maps the constant keys to a value.
 This method can be optionally implemented in a sub-class.
 The default implementation returns an array of keys mapped to `null`.
 
+### instances()
+
+Returns an array of Enum instances.
+
 ### keys()
 
 Returns an array of constant keys.
@@ -173,7 +177,7 @@ Returns an array of all the constant names declared with the class.
 
 ### namesAndKeys()
 
-Returns an associative array of CONSTANT_NAME => key, for all of the constant names declared within the class.
+Returns an associative array of CONSTANT_NAME => key, for all the constant names declared within the class.
 
 ### keyForName(string $name)
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -64,6 +64,18 @@ abstract class Enum
     }
 
     /**
+     * Return set of every instance
+     *
+     * @return static[]
+     */
+    public static function instances(): array
+    {
+        return array_map(function ($key) {
+            return self::instanceFromKey($key);
+        }, self::keys());
+    }
+
+    /**
      * Returns a cached version of the map
      * It not only ensures the array supplied by map() is indexed by key,
      * it allows map() to do any intensive one-off operations.

--- a/tests/Unit/EnumTest.php
+++ b/tests/Unit/EnumTest.php
@@ -64,4 +64,24 @@ class EnumTest extends TestCase
             ['you', 'filthy', 'animal'],
         ], Animal::values());
     }
+
+    public function test_can_get_instances()
+    {
+        $instances = Animal::instances();
+
+        foreach ($instances as $animal) {
+            self::assertInstanceOf(Animal::class, $animal);
+        }
+
+        $keys = array_map(function (Animal $animal) {
+            return $animal->key();
+        }, $instances);
+
+        self::assertEquals([
+            Animal::CAT,
+            Animal::DOG,
+            Animal::HORSE,
+            Animal::PIGEON,
+        ], $keys);
+    }
 }


### PR DESCRIPTION
Add static helper method to get all instances in an enum.

```php
// With new feature
$instances = MyEnum::instances();
```

Previously would have had to map them manually.

```php
// without feature
$instances = array_map(fn ($key) => MyEnum::instanceFromKey($key), MyEnum::keys());
```
