### PR TITLE
feat: Adds isNot, isAnyOf, isNoneOf methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ $city->value()['population'];        // null - no value mapped
 $city->is(City::BRISBANE);           // (boolean)true
 $city->is(City::BRISBANE());         // (boolean)true
 $city->is(City::SYDNEY());           // (boolean)false
+$city->isNot(City::SYDNEY());        // (boolean)true
+$city->isAnyOf([City::BRISBANE()]);  // (boolean)true
+$city->isNoneOf([City::BRISBANE()]); // (boolean)false
 
 // Or ...
 City::SYDNEY()->key();               // "Sydney"

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -381,7 +381,7 @@ abstract class Enum
         if (is_scalar($compare)) {
             return $compare === $this->key();
         }
-        
+
         $given = is_object($compare)
             ? get_class($compare) . ' instance'
             : gettype($compare);
@@ -389,5 +389,50 @@ abstract class Enum
         throw new InvalidEnumException(
             'Enum instance or key (scalar) expected but ' . $given . ' given.'
         );
+    }
+
+    /**
+     * Returns false if this instance is equal to the given key or Enum instance.
+     *
+     * @param static|mixed $compare
+     *
+     * @return bool
+     * @throws InvalidEnumException
+     */
+    public function isNot($compare): bool
+    {
+        return !$this->is($compare);
+    }
+
+    /**
+     * Returns true if this instance exists in the list of given keys or Enum instances.
+     *
+     * @param static[]|mixed[] $compares
+     *
+     * @return bool
+     * @throws InvalidEnumException
+     */
+    public function isAnyOf(array $compares): bool
+    {
+        foreach($compares as $compare){
+            if( $this->is($compare) ){
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns false if this instance exists in the list of given keys or Enum instances.
+     *
+     * @param static[]|mixed[] $compares
+     *
+     * @return bool
+     * @throws InvalidEnumException
+     */
+    public function isNoneOf(array $compares): bool
+    {
+        return !$this->isAnyOf($compares);
     }
 }

--- a/tests/Unit/ComparisonTest.php
+++ b/tests/Unit/ComparisonTest.php
@@ -34,6 +34,24 @@ class ComparisonTest extends TestCase
         self::assertTrue(Number::TWENTY_FOUR()->is(24));
     }
 
+    public function test_is_not_comparison()
+    {
+        self::assertFalse(Fruit::APPLE()->isNot(Fruit::APPLE()));
+        self::assertTrue(Fruit::APPLE()->isNot(Fruit::BANANA()));
+    }
+
+    public function test_is_any_of_comparison()
+    {
+        self::assertTrue(Fruit::APPLE()->isAnyOf([Fruit::APPLE(), Fruit::BANANA()]));
+        self::assertFalse(Fruit::APPLE()->isAnyOf([Fruit::BANANA(), Fruit::CHERRY(), Fruit::EGGPLANT()]));
+    }
+
+    public function test_is_none_of_comparison()
+    {
+        self::assertFalse(Fruit::APPLE()->isNoneOf([Fruit::APPLE(), Fruit::BANANA()]));
+        self::assertTrue(Fruit::APPLE()->isNoneOf([Fruit::BANANA(), Fruit::CHERRY(), Fruit::EGGPLANT()]));
+    }
+
     public function test_comparing_enum_to_an_invalid_argument_throws_exception()
     {
         $this->expectException(InvalidEnumException::class);


### PR DESCRIPTION
Adds new `isNot`, `isAnyOf` and `isNoneOf` methods + corresponding tests.
 
Inputs for methods compatible with existing `is` method.

Background on improvement is here: https://github.com/rexlabsio/enum-php/discussions/12